### PR TITLE
Improve codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To use the Solana Sniper, you will need the following:
 - Discord Webhook urls.
 - Telegram bot api keys.
 - Solana RPC Provider's HTTPS URL
+- Jupiter SWAP API HTTPS URL
 - Kokiez API key (PAID) - It is used in this open source project to fetch pool info (This key is not your one way ticket to become a millionaire, a proof is given in the video of how I got rugged while sniping new pools naively!)
 
 ## Getting Started
@@ -28,7 +29,7 @@ To use the Solana Sniper, you will need the following:
     git clone https://github.com/kokiez/solana-sniper.git
     cd solana-sniper
     ```
-2. Watch the [Video](https://www.youtube.com/watch?v=ZXS4OGUE17k) or Read it here in detail, [Click me](https://github.com/kokiez/solana-sniper/blob/main/guide.md)
+2. Watch the [Video](https://www.youtube.com/watch?v=ZXS4OGUE17k) or Read it here in detail, [Click me](./blob/main/guide.md)
 - Note: Currently, the sniper is set to check for "new pool" and a solscan.com/tx/blabla url in a new message to snipe new pools... but you can change it to your liking. Example:
    ```
    NEW POOL
@@ -85,3 +86,4 @@ Happy trading with the Solana Sniper!
 7) [https://michaelhly.com/solana-py/](https://michaelhly.com/solana-py/)
 8) [https://www.soldev.app/course/intro-to-reading-data](https://www.soldev.app/course/intro-to-reading-data)
 9) [https://kevinheavey.github.io/solders/index.html](https://kevinheavey.github.io/solders/index.html)
+10) [https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api)

--- a/data/config.ini
+++ b/data/config.ini
@@ -11,6 +11,7 @@ KEEP_JUPITER_DISABLED = True
 ; So assuming you dont know what an rpc is and what difference it makes in sending a txn, 
 ; I'll not implement new pools monitoring from the network in this project. DYOR and implement it on your own!)
 NEW_POOL = True
+BASE_URL = https://public.jupiterapi.com
 
 [INVESTMENT]
 ; I want to send buy attemps 10 seconds before pool actually opens...

--- a/guide.md
+++ b/guide.md
@@ -39,7 +39,11 @@ I created an api, so everyone can fetch pool info at much faster rate. You can t
       2) 30$ for 30 days
 
 ## Section 7: RPC URL
-1. Goto [helius](https://helius.xyz/) and create your endpoint for solana. Copy the https url and add it to config.ini
+1. Goto [QuickNode](https://www.quicknode.com/) and create your endpoint for solana. Copy the https url and add it to config.ini
+2. Goto [helius](https://helius.xyz/) and create your endpoint for solana. Copy the https url and add it to config.ini
+
+## Section 8: Jupiter URL
+1. Goto [QuickNode](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api) and add the Metis endpoint for solana. Sign into the metis dashboard and copy the https url and add it to config.ini
 
 ## Finally
 1. You can create a test channel using main telegram account, then join it with the one that is suppose to be in the solana sniper bot, and then add the username of channel to config.ini.

--- a/jupiter/buy_swap.py
+++ b/jupiter/buy_swap.py
@@ -26,7 +26,7 @@ def buy(payer, ctx, amount_of_sol_to_swap, TOKEN_TO_SWAP_BUY, config):
             # Swap Info
             print("3. Get Route for swap...")
 
-            quote_response = requests.get('https://quote-api.jup.ag/v6/quote', params={
+            quote_response = requests.get(config.get("JUPITER", "BASE_URL") + '/quote', params={
                 'inputMint': 'So11111111111111111111111111111111111111112',
                 'outputMint': TOKEN_TO_SWAP_BUY,
                 'amount': amount_of_sol_to_swap,
@@ -45,7 +45,7 @@ def buy(payer, ctx, amount_of_sol_to_swap, TOKEN_TO_SWAP_BUY, config):
 # ========================================================================================================
             print("4. Get the serialized transactions to perform the swap...")
             # Get the serialized transactions to perform the swap
-            url = "https://quote-api.jup.ag/v6/swap"
+            url = config.get("JUPITER", "BASE_URL") + "/swap"
             payload = json.dumps({
             "userPublicKey": str(payer.pubkey()),
             "wrapAndUnwrapSol": True,

--- a/jupiter/sell_swap.py
+++ b/jupiter/sell_swap.py
@@ -48,7 +48,7 @@ def sell(ctx, payer, TOKEN_TO_SWAP_SELL, config):
             print("Token Balance [Lamports]: ",tokenBalanceLamports)
             print("3. Get Route for swap...")
 
-            quote_response = requests.get('https://quote-api.jup.ag/v6/quote', params={
+            quote_response = requests.get(config.get("JUPITER", "BASE_URL") + '/quote', params={
                 'inputMint': TOKEN_TO_SWAP_SELL,
                 'outputMint': 'So11111111111111111111111111111111111111112',
                 'amount': tokenBalanceLamports,
@@ -57,7 +57,7 @@ def sell(ctx, payer, TOKEN_TO_SWAP_SELL, config):
 # ========================================================================================================
             print("4. Get the serialized transactions to perform the swap...")
             # Get the serialized transactions to perform the swap
-            url = "https://quote-api.jup.ag/v6/swap"
+            url = config.get("JUPITER", "BASE_URL") + "/swap"
             payload = json.dumps({
             "userPublicKey": str(payer.pubkey()),
             "wrapAndUnwrapSol": True,

--- a/utils/computePrice.py
+++ b/utils/computePrice.py
@@ -77,7 +77,7 @@ def getQuoteToken(TOKEN_TO_SWAP_SELL, tokenBalanceLamports):
 
         
         while True:
-            quote_response1 = requests.get('https://quote-api.jup.ag/v6/quote', params={
+            quote_response1 = requests.get(config.get("JUPITER", "BASE_URL") + '/quote', params={
                 'inputMint': TOKEN_TO_SWAP_SELL,
                 'outputMint': 'So11111111111111111111111111111111111111112',
                 'amount': tokenBalanceLamports,


### PR DESCRIPTION
This PR adjusts the API constants provided for the jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides. More details can be found on their site.

I also updated the README.md to provide options to other endpoints in case higher rate limits are needed.